### PR TITLE
Series of misc improvements

### DIFF
--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -127,7 +127,7 @@ namespace glTFRevitExport
     /// https://github.com/va3c/RvtVa3c
     /// An integer-based 3D point class.
     /// </summary>
-    class PointInt : IComparable<PointInt>
+    public class PointInt : IComparable<PointInt>
     {
         public long X { get; set; }
         public long Y { get; set; }
@@ -200,7 +200,7 @@ namespace glTFRevitExport
     /// A vertex lookup class to eliminate 
     /// duplicate vertex definitions.
     /// </summary>
-    class VertexLookupInt : Dictionary<PointInt, int>
+    public class VertexLookupInt : Dictionary<PointInt, int>
     {
         /// <summary>
         /// Define equality for integer-based PointInt.

--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -9,7 +9,7 @@ namespace glTFRevitExport
     /// converting between Revit Polymesh
     /// and glTF buffers.
     /// </summary>
-    class GeometryData
+    public class GeometryData
     {
         public VertexLookupInt vertDictionary = new VertexLookupInt();
         public List<long> vertices = new List<long>();
@@ -23,7 +23,7 @@ namespace glTFRevitExport
     /// that is also addressable by a unique ID.
     /// </summary>
     /// <typeparam name="T">The type of item contained.</typeparam>
-    class IndexedDictionary<T>
+    public class IndexedDictionary<T>
     {
         private Dictionary<string, int> _dict = new Dictionary<string, int>();
         public List<T> List { get; } = new List<T>();

--- a/glTFRevitExport/GLTFManager.cs
+++ b/glTFRevitExport/GLTFManager.cs
@@ -417,25 +417,27 @@ namespace glTFRevitExport
                 mesh.primitives.Add(primative);
             }
 
-            // Prevent mesh duplication by hash checking
-            string meshHash = ManagerUtils.GenerateSHA256Hash(mesh);
-            ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(meshHash);
-            int idx = meshContainers.FindIndex(hs.EqualTo);
+            // glTF entity can not be empty
+            if (mesh.primitives.Count() > 0) {
+                // Prevent mesh duplication by hash checking
+                string meshHash = ManagerUtils.GenerateSHA256Hash(mesh);
+                ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(meshHash);
+                int idx = meshContainers.FindIndex(hs.EqualTo);
 
-            if (idx != -1)
-            {
-                // set the current nodes mesh index to the already
-                // created mesh location.
-                nodeDict[currentNodeId].mesh = idx;
-            }
-            else
-            {
-                // create new mesh and add it's index to the current node.
-                MeshContainer mc = new MeshContainer();
-                mc.hashcode = meshHash;
-                mc.contents = mesh;
-                meshContainers.Add(mc);
-                nodeDict[currentNodeId].mesh = meshContainers.Count - 1;
+                if (idx != -1) {
+                    // set the current nodes mesh index to the already
+                    // created mesh location.
+                    nodeDict[currentNodeId].mesh = idx;
+                }
+                else {
+                    // create new mesh and add it's index to the current node.
+                    MeshContainer mc = new MeshContainer();
+                    mc.hashcode = meshHash;
+                    mc.contents = mesh;
+                    meshContainers.Add(mc);
+                    nodeDict[currentNodeId].mesh = meshContainers.Count - 1;
+                }
+
             }
 
             geometryStack.Pop();

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -139,7 +139,7 @@ namespace glTFRevitExport
                 container.glTF.buffers.Clear();
                 container.glTF.buffers.Add(buffer);
 
-                using (FileStream f = File.Create(_filename + ".bin"))
+                using (FileStream f = File.Create(Path.Combine(_directory, _filename + ".bin")))
                 {
                     using (BinaryWriter writer = new BinaryWriter(f))
                     {
@@ -163,7 +163,7 @@ namespace glTFRevitExport
                 // Write the *.bin files
                 foreach (var bin in container.binaries)
                 {
-                    using (FileStream f = File.Create(_directory + bin.name))
+                    using (FileStream f = File.Create(Path.Combine(_directory, bin.name)))
                     {
                         using (BinaryWriter writer = new BinaryWriter(f))
                         {

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -39,11 +39,12 @@ namespace glTFRevitExport
         private glTFExportConfigs _cfgs = new glTFExportConfigs();
 
         /// <summary>
-        /// The name for the .gltf file.
+        /// The name for the export files
         /// </summary>
         private string _filename;
+        
         /// <summary>
-        /// The directory for the .bin files.
+        /// The directory for the export files
         /// </summary>
         private string _directory;
 
@@ -63,7 +64,8 @@ namespace glTFRevitExport
         {
             documentStack.Push(doc);
 
-            _filename = filename;
+            // ensure filename is really a file name and no extension
+            _filename = Path.GetFileNameWithoutExtension(filename);
             _directory = directory;
             _cfgs = configs is null ? _cfgs : configs;
         }
@@ -146,15 +148,13 @@ namespace glTFRevitExport
                     }
                 }
 
-                string fileEnd = _filename.Substring(_directory.Count());
-
                 glTFBuffer buffer = new glTFBuffer();
                 buffer.uri = _filename + ".bin";
                 buffer.byteLength = bytePosition;
                 container.glTF.buffers.Clear();
                 container.glTF.buffers.Add(buffer);
 
-                using (FileStream f = File.Create(Path.Combine(_directory, _filename + ".bin")))
+                using (FileStream f = File.Create(Path.Combine(_directory, buffer.uri)))
                 {
                     using (BinaryWriter writer = new BinaryWriter(f))
                     {
@@ -198,7 +198,7 @@ namespace glTFRevitExport
 
             // Write the *.gltf file
             string serializedModel = JsonConvert.SerializeObject(container.glTF, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-            File.WriteAllText(_filename, serializedModel);
+            File.WriteAllText(Path.Combine(_directory, _filename + ".gltf"), serializedModel);
         }
 
         /// <summary>

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -151,7 +151,7 @@ namespace glTFRevitExport
                 string fileEnd = _filename.Substring(_directory.Count());
 
                 glTFBuffer buffer = new glTFBuffer();
-                buffer.uri = fileEnd + ".bin";
+                buffer.uri = _filename + ".bin";
                 buffer.byteLength = bytePosition;
                 container.glTF.buffers.Clear();
                 container.glTF.buffers.Add(buffer);

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -36,9 +36,6 @@ namespace glTFRevitExport
 
     public class glTFExportContext : IExportContext
     {
-        private Document _doc;
-        private bool _skipElementFlag = false;
-
         private glTFExportConfigs _cfgs = new glTFExportConfigs();
 
         /// <summary>
@@ -50,6 +47,7 @@ namespace glTFRevitExport
         /// </summary>
         private string _directory;
 
+        private bool _skipElementFlag = false;
 
         private GLTFManager manager = new GLTFManager();
         private Stack<Document> documentStack = new Stack<Document>();
@@ -78,7 +76,7 @@ namespace glTFRevitExport
         public bool Start()
         {
             Debug.WriteLine("Starting...");
-            manager.Start(_exportProperties);
+            manager.Start(_cfgs.ExportProperties);
             return true;
         }
 

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace glTFRevitExport
 {
-    class glTFExportContext : IExportContext
+    public class glTFExportContext : IExportContext
     {
         private bool _skipElementFlag = false;
 


### PR DESCRIPTION
- marked api as public
- glTF exporter now accepts a config object instead of arguments
- exporting non-standard elements is now optional `glTFExportConfigs.IncludeNonStdElements`
- `filename` is only the main file name and not the full path.`directory` will contains all the files.
    - in single binary, the is one file called `<filename>.bin`
    - in multi file, there is one `<filename>.gltf` and a series of `*.bin` buffers