### PR TITLE
Xforms

### DIFF
--- a/glTFRevitExport.sln
+++ b/glTFRevitExport.sln
@@ -1,20 +1,34 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.645
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "glTFRevitExport", "glTFRevitExport\glTFRevitExport.csproj", "{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug2017|Any CPU = Debug2017|Any CPU
+		Debug2018|Any CPU = Debug2018|Any CPU
+		Debug2019|Any CPU = Debug2019|Any CPU
+		Debug2020|Any CPU = Debug2020|Any CPU
+		Debug2021|Any CPU = Debug2021|Any CPU
+		Release2017|Any CPU = Release2017|Any CPU
+		Release2018|Any CPU = Release2018|Any CPU
+		Release2019|Any CPU = Release2019|Any CPU
+		Release2020|Any CPU = Release2020|Any CPU
+		Release2021|Any CPU = Release2021|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug2017|Any CPU.ActiveCfg = Debug2017|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug2018|Any CPU.ActiveCfg = Debug2018|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug2019|Any CPU.ActiveCfg = Debug2019|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug2020|Any CPU.ActiveCfg = Debug2020|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Debug2021|Any CPU.ActiveCfg = Debug2021|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release2017|Any CPU.ActiveCfg = Release2017|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release2018|Any CPU.ActiveCfg = Release2018|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release2019|Any CPU.ActiveCfg = Release2019|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release2020|Any CPU.ActiveCfg = Release2020|x64
+		{4E089540-E5C0-45D9-BB33-3CBA0E4373B5}.Release2021|Any CPU.ActiveCfg = Release2021|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -11,6 +11,7 @@ namespace glTFRevitExport
     /// </summary>
     class GeometryData
     {
+        public VertexLookupInt vertDictionary = new VertexLookupInt();
         public List<long> vertices = new List<long>();
         public List<double> normals = new List<double>();
         public List<double> uvs = new List<double>();
@@ -127,42 +128,42 @@ namespace glTFRevitExport
     /// A vertex lookup class to eliminate 
     /// duplicate vertex definitions.
     /// </summary>
-    class VertexLookupXyz : Dictionary<XYZ, int>
-    {
-        /// <summary>
-        /// Define equality for Revit XYZ points.
-        /// Very rough tolerance, as used by Revit itself.
-        /// </summary>
-        class XyzEqualityComparer : IEqualityComparer<XYZ>
-        {
-            const double _sixteenthInchInFeet = 1.0 / (16.0 * 12.0);
+    //class VertexLookupXyz : Dictionary<XYZ, int>
+    //{
+    //    /// <summary>
+    //    /// Define equality for Revit XYZ points.
+    //    /// Very rough tolerance, as used by Revit itself.
+    //    /// </summary>
+    //    class XyzEqualityComparer : IEqualityComparer<XYZ>
+    //    {
+    //        const double _sixteenthInchInFeet = 1.0 / (16.0 * 12.0);
 
-            public bool Equals(XYZ p, XYZ q)
-            {
-                return p.IsAlmostEqualTo(q, _sixteenthInchInFeet);
-            }
+    //        public bool Equals(XYZ p, XYZ q)
+    //        {
+    //            return p.IsAlmostEqualTo(q, _sixteenthInchInFeet);
+    //        }
 
-            public int GetHashCode(XYZ p)
-            {
-                return Util.PointString(p).GetHashCode();
-            }
-        }
+    //        public int GetHashCode(XYZ p)
+    //        {
+    //            return Util.PointString(p).GetHashCode();
+    //        }
+    //    }
 
-        public VertexLookupXyz() : base(new XyzEqualityComparer())
-        {
-        }
+    //    public VertexLookupXyz() : base(new XyzEqualityComparer())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Return the index of the given vertex,
-        /// adding a new entry if required.
-        /// </summary>
-        public int AddVertex(XYZ p)
-        {
-            return ContainsKey(p)
-              ? this[p]
-              : this[p] = Count;
-        }
-    }
+    //    /// <summary>
+    //    /// Return the index of the given vertex,
+    //    /// adding a new entry if required.
+    //    /// </summary>
+    //    public int AddVertex(XYZ p)
+    //    {
+    //        return ContainsKey(p)
+    //          ? this[p]
+    //          : this[p] = Count;
+    //    }
+    //}
 
     /// <summary>
     /// From Jeremy Tammik's RvtVa3c exporter:

--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -190,7 +190,7 @@ namespace glTFRevitExport
         /// Conversion a given length value 
         /// from feet to millimetre.
         /// </summary>
-        static long ConvertFeetToMillimetres(double d)
+        public static long ConvertFeetToMillimetres(double d)
         {
             if (0 < d)
             {

--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -9,7 +9,7 @@ namespace glTFRevitExport
     /// converting between Revit Polymesh
     /// and glTF buffers.
     /// </summary>
-    class GeometryData
+    public class GeometryData
     {
         public VertexLookupInt vertDictionary = new VertexLookupInt();
         public List<long> vertices = new List<long>();
@@ -23,7 +23,7 @@ namespace glTFRevitExport
     /// that is also addressable by a unique ID.
     /// </summary>
     /// <typeparam name="T">The type of item contained.</typeparam>
-    class IndexedDictionary<T>
+    public class IndexedDictionary<T>
     {
         private Dictionary<string, int> _dict = new Dictionary<string, int>();
         public List<T> List { get; } = new List<T>();
@@ -127,7 +127,7 @@ namespace glTFRevitExport
     /// https://github.com/va3c/RvtVa3c
     /// An integer-based 3D point class.
     /// </summary>
-    class PointInt : IComparable<PointInt>
+    public class PointInt : IComparable<PointInt>
     {
         public long X { get; set; }
         public long Y { get; set; }
@@ -200,7 +200,7 @@ namespace glTFRevitExport
     /// A vertex lookup class to eliminate 
     /// duplicate vertex definitions.
     /// </summary>
-    class VertexLookupInt : Dictionary<PointInt, int>
+    public class VertexLookupInt : Dictionary<PointInt, int>
     {
         /// <summary>
         /// Define equality for integer-based PointInt.

--- a/glTFRevitExport/Containers.cs
+++ b/glTFRevitExport/Containers.cs
@@ -125,49 +125,6 @@ namespace glTFRevitExport
     /// <summary>
     /// From Jeremy Tammik's RvtVa3c exporter:
     /// https://github.com/va3c/RvtVa3c
-    /// A vertex lookup class to eliminate 
-    /// duplicate vertex definitions.
-    /// </summary>
-    //class VertexLookupXyz : Dictionary<XYZ, int>
-    //{
-    //    /// <summary>
-    //    /// Define equality for Revit XYZ points.
-    //    /// Very rough tolerance, as used by Revit itself.
-    //    /// </summary>
-    //    class XyzEqualityComparer : IEqualityComparer<XYZ>
-    //    {
-    //        const double _sixteenthInchInFeet = 1.0 / (16.0 * 12.0);
-
-    //        public bool Equals(XYZ p, XYZ q)
-    //        {
-    //            return p.IsAlmostEqualTo(q, _sixteenthInchInFeet);
-    //        }
-
-    //        public int GetHashCode(XYZ p)
-    //        {
-    //            return Util.PointString(p).GetHashCode();
-    //        }
-    //    }
-
-    //    public VertexLookupXyz() : base(new XyzEqualityComparer())
-    //    {
-    //    }
-
-    //    /// <summary>
-    //    /// Return the index of the given vertex,
-    //    /// adding a new entry if required.
-    //    /// </summary>
-    //    public int AddVertex(XYZ p)
-    //    {
-    //        return ContainsKey(p)
-    //          ? this[p]
-    //          : this[p] = Count;
-    //    }
-    //}
-
-    /// <summary>
-    /// From Jeremy Tammik's RvtVa3c exporter:
-    /// https://github.com/va3c/RvtVa3c
     /// An integer-based 3D point class.
     /// </summary>
     class PointInt : IComparable<PointInt>

--- a/glTFRevitExport/GLTFManager.cs
+++ b/glTFRevitExport/GLTFManager.cs
@@ -1,0 +1,487 @@
+﻿using Autodesk.Revit.DB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+
+namespace glTFRevitExport
+{
+    static class ManagerUtils
+    {
+        static public List<double> ConvertXForm(Transform xform)
+        {
+            if (xform.IsIdentity) return null;
+
+            var BasisX = xform.BasisX;
+            var BasisY = xform.BasisY;
+            var BasisZ = xform.BasisZ;
+            var Origin = xform.Origin;
+            var OriginX = PointInt.ConvertFeetToMillimetres(Origin.X);
+            var OriginY = PointInt.ConvertFeetToMillimetres(Origin.Y);
+            var OriginZ = PointInt.ConvertFeetToMillimetres(Origin.Z);
+
+            List<double> glXform = new List<double>(16) {
+                BasisX.X, BasisX.Y, BasisX.Z, 0,
+                BasisY.X, BasisY.Y, BasisY.Z, 0,
+                BasisZ.X, BasisZ.Y, BasisZ.Z, 0,
+                OriginX, OriginY, OriginZ, 1
+            };
+
+            return glXform;
+        }
+
+        public class HashSearch
+        {
+            string _S;
+            public HashSearch(string s)
+            {
+                _S = s;
+            }
+            public bool EqualTo(HashedType d)
+            {
+                return d.hashcode.Equals(_S);
+            }
+        }
+
+        static public string GenerateSHA256Hash<T>(T data)
+        {
+            var binFormatter = new BinaryFormatter();
+            var mStream = new MemoryStream();
+            binFormatter.Serialize(mStream, data);
+
+            using (SHA256 hasher = SHA256.Create())
+            {
+                mStream.Position = 0;
+                byte[] byteHash = hasher.ComputeHash(mStream);
+
+                var sBuilder = new StringBuilder();
+                for (int i = 0; i < byteHash.Length; i++)
+                {
+                    sBuilder.Append(byteHash[i].ToString("x2"));
+                }
+
+                return sBuilder.ToString();
+            }
+        }
+    }
+
+    class GLTFManager
+    {
+        private IndexedDictionary<glTFMaterial> materialDict = new IndexedDictionary<glTFMaterial>();
+        private Dictionary<string, Node> nodeDict = new Dictionary<string, Node>();
+        private List<MeshContainer> meshContainers = new List<MeshContainer>();
+
+        public List<glTFScene> scenes = new List<glTFScene>();
+        public List<glTFBuffer> buffers = new List<glTFBuffer>();
+        public List<glTFBufferView> bufferViews = new List<glTFBufferView>();
+        public List<glTFAccessor> accessors = new List<glTFAccessor>();
+        public List<glTFBinaryData> binaryFileData = new List<glTFBinaryData>();
+
+        public List<glTFNode> nodes {
+            get {
+                var list = nodeDict.Values.ToList();
+                return list.OrderBy(x => x.index).Select(x => x.ToGLTFNode()).ToList();
+            }
+        }
+
+        public List<glTFMaterial> materials {
+            get {
+                return materialDict.List;
+            }
+        }
+
+        public List<glTFMesh> meshes {
+            get {
+                return meshContainers.Select(x => x.contents).ToList();
+            }
+        }
+
+        private bool _flipCoords = false;
+        private bool _exportProperties = true;
+
+        private string currentNodeId;
+        private Dictionary<string, GeometryData> currentGeometry;
+        private Stack<string> parentStack = new Stack<string>();
+
+        public void Start(bool exportProperties = true)
+        {
+            this._exportProperties = exportProperties;
+
+            Node rootNode = new Node(0);
+            rootNode.children = new List<int>();
+            nodeDict.Add(rootNode.id, rootNode);
+
+            glTFScene defaultScene = new glTFScene();
+            defaultScene.nodes.Add(0);
+            scenes.Add(defaultScene);
+        }
+
+        public glTFContainer Finish()
+        {
+            glTF model = new glTF();
+            model.asset = new glTFVersion();
+            model.scenes = scenes;
+            model.nodes = nodes;
+            model.meshes = meshes;
+            model.materials = materials;
+            model.buffers = buffers;
+            model.bufferViews = bufferViews;
+            model.accessors = accessors;
+
+            glTFContainer container = new glTFContainer();
+            container.glTF = model;
+            container.binaries = binaryFileData;
+
+            return container;
+        }
+
+        public void openNode(Element elem, Transform xform = null)
+        {
+            if (nodeDict.ContainsKey(elem.UniqueId)) return;
+
+            Node node = new Node(elem, nodeDict.Count, _exportProperties);
+            if (parentStack.Count > 0)
+            {
+                string parentId = parentStack.Peek();
+                Node parentNode = nodeDict[parentId];
+                if (parentNode.children == null) parentNode.children = new List<int>();
+                nodeDict[parentId].children.Add(node.index);
+            }
+
+            parentStack.Push(node.id);
+            if (xform != null)
+            {
+                node.matrix = ManagerUtils.ConvertXForm(xform);
+            }
+
+            nodeDict.Add(node.id, node);
+            currentNodeId = node.id;
+
+            // TODO: do geometry initialization
+            openGeometry();
+        }
+
+        public void closeNode(Element elem)
+        {
+            Node node = nodeDict[elem.UniqueId];
+            node.isFinalized = true;
+            currentNodeId = null;
+
+            // do geometry finalization
+            closeGeometry();
+
+            // retreat back up parent tree
+            parentStack.Pop();
+        }
+
+        public void switchMaterial(MaterialNode matNode, string name = null, string id = null)
+        {
+            glTFMaterial gl_mat = new glTFMaterial();
+            string uniqueId = id;
+            if (uniqueId == null)
+            {
+                uniqueId = string.Format("r{0}g{1}b{2}", matNode.Color.Red.ToString(), matNode.Color.Green.ToString(), matNode.Color.Blue.ToString());
+                gl_mat.name = string.Format("MaterialNode_{0}_{1}", Util.ColorToInt(matNode.Color), Util.RealString(matNode.Transparency * 100));
+
+                glTFPBR pbr = new glTFPBR();
+                pbr.baseColorFactor = new List<float>() { matNode.Color.Red / 255f, matNode.Color.Green / 255f, matNode.Color.Blue / 255f, (float)matNode.Transparency * 255 };
+                pbr.metallicFactor = 0f;
+                pbr.roughnessFactor = 1f;
+                gl_mat.pbrMetallicRoughness = pbr;
+            } else
+            {
+                gl_mat.name = name;
+                glTFPBR pbr = new glTFPBR();
+                pbr.baseColorFactor = new List<float>() { matNode.Color.Red / 255f, matNode.Color.Green / 255f, matNode.Color.Blue / 255f, (float)matNode.Transparency * 255 };
+                pbr.metallicFactor = 0f;
+                pbr.roughnessFactor = 1f;
+                gl_mat.pbrMetallicRoughness = pbr;
+            }
+
+            materialDict.AddOrUpdateCurrent(uniqueId, gl_mat);
+        }
+
+        public void openGeometry()
+        {
+            currentGeometry = new Dictionary<string, GeometryData>();
+        }
+
+        public void onGeometry(PolymeshTopology polymesh)
+        {
+            if (currentNodeId == null) throw new Exception();
+            string vertex_key = currentNodeId + "_" + materialDict.CurrentKey;
+            if (currentGeometry.ContainsKey(vertex_key) == false)
+            {
+                currentGeometry.Add(vertex_key, new GeometryData());
+            }
+
+            // Populate normals from this polymesh
+            IList<XYZ> norms = polymesh.GetNormals();
+            foreach (XYZ norm in norms)
+            {
+                currentGeometry[vertex_key].normals.Add(norm.X);
+                currentGeometry[vertex_key].normals.Add(norm.Y);
+                currentGeometry[vertex_key].normals.Add(norm.Z);
+            }
+
+            // Populate vertex and faces data
+            IList<XYZ> pts = polymesh.GetPoints();
+            foreach (PolymeshFacet facet in polymesh.GetFacets())
+            {
+                int v1 = currentGeometry[vertex_key].vertDictionary.AddVertex(new PointInt(pts[facet.V1], _flipCoords));
+                int v2 = currentGeometry[vertex_key].vertDictionary.AddVertex(new PointInt(pts[facet.V2], _flipCoords));
+                int v3 = currentGeometry[vertex_key].vertDictionary.AddVertex(new PointInt(pts[facet.V3], _flipCoords));
+
+                currentGeometry[vertex_key].faces.Add(v1);
+                currentGeometry[vertex_key].faces.Add(v2);
+                currentGeometry[vertex_key].faces.Add(v3);
+            }
+        }
+
+        public void closeGeometry()
+        {
+            // Create the new mesh and populate the primitives with GeometryData
+            glTFMesh mesh = new glTFMesh();
+            mesh.primitives = new List<glTFMeshPrimitive>();
+
+            // transfer ordered vertices from vertex dictionary to vertices list
+            foreach (KeyValuePair<string,GeometryData> key_geom in currentGeometry)
+            {
+                string key = key_geom.Key;
+                GeometryData geom = key_geom.Value;
+                foreach (KeyValuePair<PointInt, int> point_index in geom.vertDictionary)
+                {
+                    PointInt point = point_index.Key;
+                    geom.vertices.Add(point.X);
+                    geom.vertices.Add(point.Y);
+                    geom.vertices.Add(point.Z);
+                }
+
+                // convert GeometryData objects into glTFMeshPrimitive
+                string material_key = key.Split('_')[1];
+                glTFBinaryData bufferMeta = processGeometry(geom, key);
+                glTFMeshPrimitive primative = new glTFMeshPrimitive();
+
+                primative.attributes.POSITION = bufferMeta.vertexAccessorIndex;
+                primative.indices = bufferMeta.indexAccessorIndex;
+                primative.material = materialDict.GetIndexFromUUID(material_key);
+                // TODO: Add normal attribute accessor index here
+
+                mesh.primitives.Add(primative);
+            }
+
+            // Prevent mesh duplication by hash checking
+            string meshHash = ManagerUtils.GenerateSHA256Hash(mesh);
+            ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(meshHash);
+            int idx = meshContainers.FindIndex(hs.EqualTo);
+
+            if (idx != -1)
+            {
+                // set the current nodes mesh index to the already
+                // created mesh location.
+                nodeDict[currentNodeId].mesh = idx;
+            }
+            else
+            {
+                // create new mesh and add it's index to the current node.
+                MeshContainer mc = new MeshContainer();
+                mc.hashcode = meshHash;
+                mc.contents = mesh;
+                meshContainers.Add(mc);
+                nodeDict[currentNodeId].mesh = meshContainers.Count - 1;
+            }
+
+            // Clear the geometry
+            currentGeometry = null;
+            return;
+        }
+
+        private glTFBinaryData processGeometry(GeometryData geom, string name)
+        {
+            // TODO: rename this type to glTFBufferMeta ?
+            glTFBinaryData bufferData = new glTFBinaryData();
+            glTFBinaryBufferContents bufferContents = new glTFBinaryBufferContents();
+
+            foreach (var coord in geom.vertices)
+            {
+                float vFloat = Convert.ToSingle(coord);
+                bufferContents.vertexBuffer.Add(vFloat);
+            }
+            foreach (var index in geom.faces)
+            {
+                bufferContents.indexBuffer.Add(index);
+            }
+
+            // Prevent buffer duplication by hash checking
+            string calculatedHash = ManagerUtils.GenerateSHA256Hash(bufferContents);
+            ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(calculatedHash);
+            var match = binaryFileData.Find(hs.EqualTo);
+
+            if (match != null)
+            {
+                // return previously created buffer metadata
+                bufferData.vertexAccessorIndex = match.vertexAccessorIndex;
+                bufferData.indexAccessorIndex = match.indexAccessorIndex;
+                return bufferData;
+            }
+            else
+            {
+                // add a buffer
+                glTFBuffer buffer = new glTFBuffer();
+                buffer.uri = name + ".bin";
+                buffers.Add(buffer);
+                int bufferIdx = buffers.Count - 1;
+
+                /**
+                 * Buffer Data
+                 **/
+                bufferData.name = buffer.uri;
+                bufferData.contents = bufferContents;
+                // TODO: Uncomment for normals
+                //foreach (var normal in geomData.normals)
+                //{
+                //    bufferData.normalBuffer.Add((float)normal);
+                //}
+
+                // Get max and min for vertex data
+                float[] vertexMinMax = Util.GetVec3MinMax(bufferContents.vertexBuffer);
+                // Get max and min for index data
+                int[] faceMinMax = Util.GetScalarMinMax(bufferContents.indexBuffer);
+                // TODO: Uncomment for normals
+                // Get max and min for normal data
+                //float[] normalMinMax = getVec3MinMax(bufferData.normalBuffer);
+
+                /**
+                 * BufferViews
+                 **/
+                // Add a vec3 buffer view
+                int elementsPerVertex = 3;
+                int bytesPerElement = 4;
+                int bytesPerVertex = elementsPerVertex * bytesPerElement;
+                int numVec3 = (geom.vertices.Count) / elementsPerVertex;
+                int sizeOfVec3View = numVec3 * bytesPerVertex;
+                glTFBufferView vec3View = new glTFBufferView();
+                vec3View.buffer = bufferIdx;
+                vec3View.byteOffset = 0;
+                vec3View.byteLength = sizeOfVec3View;
+                vec3View.target = Targets.ARRAY_BUFFER;
+                bufferViews.Add(vec3View);
+                int vec3ViewIdx = bufferViews.Count - 1;
+
+                // TODO: Add a normals (vec3) buffer view
+
+                // Add a faces / indexes buffer view
+                int elementsPerIndex = 1;
+                int bytesPerIndexElement = 4;
+                int bytesPerIndex = elementsPerIndex * bytesPerIndexElement;
+                int numIndexes = geom.faces.Count;
+                int sizeOfIndexView = numIndexes * bytesPerIndex;
+                glTFBufferView facesView = new glTFBufferView();
+                facesView.buffer = bufferIdx;
+                facesView.byteOffset = vec3View.byteLength;
+                facesView.byteLength = sizeOfIndexView;
+                facesView.target = Targets.ELEMENT_ARRAY_BUFFER;
+                bufferViews.Add(facesView);
+                int facesViewIdx = bufferViews.Count - 1;
+
+                buffers[bufferIdx].byteLength = vec3View.byteLength + facesView.byteLength;
+
+                /**
+                 * Accessors
+                 **/
+                // add a position accessor
+                glTFAccessor positionAccessor = new glTFAccessor();
+                positionAccessor.bufferView = vec3ViewIdx;
+                positionAccessor.byteOffset = 0;
+                positionAccessor.componentType = ComponentType.FLOAT;
+                positionAccessor.count = geom.vertices.Count / elementsPerVertex;
+                positionAccessor.type = "VEC3";
+                positionAccessor.max = new List<float>() { vertexMinMax[1], vertexMinMax[3], vertexMinMax[5] };
+                positionAccessor.min = new List<float>() { vertexMinMax[0], vertexMinMax[2], vertexMinMax[4] };
+                accessors.Add(positionAccessor);
+                bufferData.vertexAccessorIndex = accessors.Count - 1;
+
+                // TODO: Uncomment for normals
+                // add a normals accessor
+                //glTFAccessor normalsAccessor = new glTFAccessor();
+                //normalsAccessor.bufferView = vec3ViewIdx;
+                //normalsAccessor.byteOffset = (positionAccessor.count) * bytesPerVertex;
+                //normalsAccessor.componentType = ComponentType.FLOAT;
+                //normalsAccessor.count = geom.data.normals.Count / elementsPerVertex;
+                //normalsAccessor.type = "VEC3";
+                //normalsAccessor.max = new List<float>() { normalMinMax[1], normalMinMax[3], normalMinMax[5] };
+                //normalsAccessor.min = new List<float>() { normalMinMax[0], normalMinMax[2], normalMinMax[4] };
+                //this.accessors.Add(normalsAccessor);
+                //bufferData.normalsAccessorIndex = this.accessors.Count - 1;
+
+                // add a face accessor
+                glTFAccessor faceAccessor = new glTFAccessor();
+                faceAccessor.bufferView = facesViewIdx;
+                faceAccessor.byteOffset = 0;
+                faceAccessor.componentType = ComponentType.UNSIGNED_INT;
+                faceAccessor.count = numIndexes;
+                faceAccessor.type = "SCALAR";
+                faceAccessor.max = new List<float>() { faceMinMax[1] };
+                faceAccessor.min = new List<float>() { faceMinMax[0] };
+                accessors.Add(faceAccessor);
+                bufferData.indexAccessorIndex = accessors.Count - 1;
+
+                bufferData.hashcode = calculatedHash;
+
+                return bufferData;
+            }
+        }
+    }
+
+    class Node : glTFNode
+    {
+        public int index;
+        public string id;
+        public bool isFinalized = false;
+
+        public Node(Element elem, int index, bool exportProperties = true)
+        {
+            this.name = Util.ElementDescription(elem);
+            this.id = elem.UniqueId;
+            this.index = index;
+
+            if (exportProperties)
+            {
+                // get the extras for this element
+                glTFExtras extras = new glTFExtras();
+                extras.UniqueId = elem.UniqueId;
+                extras.Properties = Util.GetElementProperties(elem, true);
+                this.extras = extras;
+            }
+        }
+        public Node(int index)
+        {
+            this.name = "::rootNode::";
+            this.id = System.Guid.NewGuid().ToString();
+            this.index = index;
+        }
+        public Node(glTFNode node)
+        {
+            this.name = node.name;
+            this.mesh = node.mesh;
+            this.matrix = node.matrix;
+            this.extras = node.extras;
+            this.children = node.children;
+        }
+
+        public glTFNode ToGLTFNode()
+        {
+            glTFNode node = new glTFNode();
+            node.name = this.name;
+            node.mesh = this.mesh;
+            node.matrix = this.matrix;
+            node.extras = this.extras;
+            node.children = this.children;
+            return node;
+        }
+    }
+}

--- a/glTFRevitExport/GLTFManager.cs
+++ b/glTFRevitExport/GLTFManager.cs
@@ -417,25 +417,27 @@ namespace glTFRevitExport
                 mesh.primitives.Add(primative);
             }
 
-            // Prevent mesh duplication by hash checking
-            string meshHash = ManagerUtils.GenerateSHA256Hash(mesh);
-            ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(meshHash);
-            int idx = meshContainers.FindIndex(hs.EqualTo);
+            // glTF entity can not be empty
+            if (mesh.primitives.Count() > 0) {
+                // Prevent mesh duplication by hash checking
+                string meshHash = ManagerUtils.GenerateSHA256Hash(mesh);
+                ManagerUtils.HashSearch hs = new ManagerUtils.HashSearch(meshHash);
+                int idx = meshContainers.FindIndex(hs.EqualTo);
 
-            if (idx != -1)
-            {
-                // set the current nodes mesh index to the already
-                // created mesh location.
-                nodeDict[currentNodeId].mesh = idx;
-            }
-            else
-            {
-                // create new mesh and add it's index to the current node.
-                MeshContainer mc = new MeshContainer();
-                mc.hashcode = meshHash;
-                mc.contents = mesh;
-                meshContainers.Add(mc);
-                nodeDict[currentNodeId].mesh = meshContainers.Count - 1;
+                if (idx != -1) {
+                    // set the current nodes mesh index to the already
+                    // created mesh location.
+                    nodeDict[currentNodeId].mesh = idx;
+                }
+                else {
+                    // create new mesh and add it's index to the current node.
+                    MeshContainer mc = new MeshContainer();
+                    mc.hashcode = meshHash;
+                    mc.contents = mesh;
+                    meshContainers.Add(mc);
+                    nodeDict[currentNodeId].mesh = meshContainers.Count - 1;
+                }
+
             }
 
             geometryStack.Pop();

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -277,9 +277,10 @@ namespace glTFRevitExport
         public RenderNodeAction OnInstanceBegin(InstanceNode node)
         {
             Debug.WriteLine(String.Format("{0}OnInstanceBegin", manager.formatDebugHeirarchy));
+            
             ElementId symId = node.GetSymbolId();
             Element symElem = _doc.GetElement(symId);
-            
+
             Debug.WriteLine(String.Format("{2}OnInstanceBegin: {0}-{1}", symId, symElem.Name, manager.formatDebugHeirarchy));
 
             var nodeXform = node.GetTransform();
@@ -296,7 +297,11 @@ namespace glTFRevitExport
         public void OnInstanceEnd(InstanceNode node)
         {
             Debug.WriteLine(String.Format("{0}OnInstanceEnd", manager.formatDebugHeirarchy.Substring(0,manager.formatDebugHeirarchy.Count() - 2)));
-            manager.CloseNode();
+
+            ElementId symId = node.GetSymbolId();
+            Element symElem = _doc.GetElement(symId);
+
+            manager.CloseNode(symElem, true);
         }
 
         public bool IsCanceled()

--- a/glTFRevitExport/GlTFExportContext.cs
+++ b/glTFRevitExport/GlTFExportContext.cs
@@ -293,8 +293,8 @@ namespace glTFRevitExport
         /// <returns></returns>
         public RenderNodeAction OnElementBegin(ElementId elementId)
         {
-            Debug.WriteLine("  OnElementBegin");
             Element e = _doc.GetElement(elementId);
+            Debug.WriteLine(String.Format("  OnElementBegin: {1}-{0}", e.Name, elementId));
 
             if (Nodes.Contains(e.UniqueId))
             {
@@ -315,11 +315,11 @@ namespace glTFRevitExport
                 extras.UniqueId = e.UniqueId;
                 extras.Properties = Util.GetElementProperties(e, true);
                 newNode.extras = extras;
-
-                Nodes.AddOrUpdateCurrent(e.UniqueId, newNode);
-                // add the index of this node to our root node children array
-                rootNode.children.Add(Nodes.CurrentIndex);
             }
+
+            Nodes.AddOrUpdateCurrent(e.UniqueId, newNode);
+            // add the index of this node to our root node children array
+            rootNode.children.Add(Nodes.CurrentIndex);
 
             // Reset _currentGeometry for new element
             _currentGeometry = new IndexedDictionary<GeometryData>();
@@ -503,8 +503,10 @@ namespace glTFRevitExport
         /// <returns></returns>
         public RenderNodeAction OnInstanceBegin(InstanceNode node)
         {
-            Debug.WriteLine("  OnInstanceBegin");
-            Debug.WriteLine(String.Format("    Instance: {0}", node.NodeName));
+            ElementId symId = node.GetSymbolId();
+            Element symElem = _doc.GetElement(symId);
+            
+            Debug.WriteLine(String.Format("  OnInstanceBegin: {0}-{1}", symId, symElem.Name));
             Debug.WriteLine(String.Format("    Mat4: {0}", node.GetTransform().IsIdentity));
 
             _transformStack.Push(

--- a/glTFRevitExport/Util.cs
+++ b/glTFRevitExport/Util.cs
@@ -231,17 +231,20 @@ namespace glTFRevitExport
             Dictionary<string, string> a = new Dictionary<string, string>(parameters.Count);
 
             // Add element category
-            a.Add("Element Category", e.Category.Name);
+            if (e.Category != null)
+            {
+                a.Add("Element Category", e.Category.Name);
+            }
 
-            string key;
-            string val;
+
 
             foreach (Parameter p in parameters)
             {
-                key = p.Definition.Name;
+                string key = p.Definition.Name;
 
                 if (!a.ContainsKey(key))
                 {
+                    string val;
                     if (StorageType.String == p.StorageType)
                     {
                         val = p.AsString();
@@ -261,17 +264,18 @@ namespace glTFRevitExport
             {
                 ElementId idType = e.GetTypeId();
 
-                if (ElementId.InvalidElementId != idType)
+                if (idType != null && ElementId.InvalidElementId != idType)
                 {
                     Document doc = e.Document;
                     Element typ = doc.GetElement(idType);
                     parameters = typ.GetOrderedParameters();
                     foreach (Parameter p in parameters)
                     {
-                        key = "Type " + p.Definition.Name;
+                        string key = "Type " + p.Definition.Name;
 
                         if (!a.ContainsKey(key))
                         {
+                            string val;
                             if (StorageType.String == p.StorageType)
                             {
                                 val = p.AsString();
@@ -288,7 +292,9 @@ namespace glTFRevitExport
                     }
                 }
             }
-            return a;
+
+            if (a.Count == 0) return null;
+            else return a;
         }
     }
 }

--- a/glTFRevitExport/glTF.cs
+++ b/glTFRevitExport/glTF.cs
@@ -49,15 +49,24 @@ namespace glTFRevitExport
     /// A binary data store serialized to a *.bin file
     /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#binary-data-storage
     /// </summary>
-    public class glTFBinaryData
+    public class glTFBinaryData : HashedType
     {
-        public List<float> vertexBuffer { get; set; } = new List<float>();
-        public List<int> indexBuffer { get; set; } = new List<int>();
+        public glTFBinaryBufferContents contents { get; set; }
+        //public List<float> vertexBuffer { get; set; } = new List<float>();
+        //public List<int> indexBuffer { get; set; } = new List<int>();
         //public List<float> normalBuffer { get; set; } = new List<float>();
         public int vertexAccessorIndex { get; set; }
         public int indexAccessorIndex { get; set; }
         //public int normalsAccessorIndex { get; set; }
         public string name { get; set; }
+        //public string hashcode { get; set; }
+    }
+
+    [Serializable]
+    public class glTFBinaryBufferContents
+    {
+        public List<float> vertexBuffer { get; set; } = new List<float>();
+        public List<int> indexBuffer { get; set; } = new List<int>();
     }
 
     /// <summary>
@@ -95,7 +104,7 @@ namespace glTFRevitExport
         /// <summary>
         /// A floating-point 4x4 transformation matrix stored in column major order.
         /// </summary>
-        public List<float> matrix { get; set; }
+        public List<double> matrix { get; set; }
         /// <summary>
         /// The indices of this node's children.
         /// </summary>
@@ -106,10 +115,22 @@ namespace glTFRevitExport
         public glTFExtras extras { get; set; }
     }
 
+    public class HashedType
+    {
+        public string hashcode { get; set; }
+    }
+
+    public class MeshContainer : HashedType
+    {
+        //public string hashcode { get; set; }
+        public glTFMesh contents { get; set; }
+    }
+
     /// <summary>
     /// The array of primitives defining the mesh of an object.
     /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes
     /// </summary>
+    [Serializable]
     public class glTFMesh
     {
         public List<glTFMeshPrimitive> primitives { get; set; }
@@ -119,6 +140,7 @@ namespace glTFRevitExport
     /// Properties defining where the GPU should look to find the mesh and material data.
     /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes
     /// </summary>
+    [Serializable]
     public class glTFMeshPrimitive
     {
         public glTFAttribute attributes { get; set; } = new glTFAttribute();
@@ -147,6 +169,7 @@ namespace glTFRevitExport
     /// The list of accessors available to the renderer for a particular mesh.
     /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes
     /// </summary>
+    [Serializable]
     public class glTFAttribute
     {
         /// <summary>
@@ -223,7 +246,7 @@ namespace glTFRevitExport
         /// </summary>
         public int count { get; set; }
         /// <summary>
-        /// Specifies if the attribute is a scala, vector, or matrix
+        /// Specifies if the attribute is a scalar, vector, or matrix
         /// </summary>
         public string type { get; set; }
         /// <summary>
@@ -256,4 +279,16 @@ namespace glTFRevitExport
         public List<double> direction { get; set; }
         public double length { get; set; }
     }
+
+    //public class glTFFunctions
+    //{
+    //    public static glTFBinaryData getMeshData(glTFNode node, glTF gltf)
+    //    {
+    //        if(node.mesh.HasValue)
+    //        {
+    //            glTFMesh mesh = gltf.meshes[node.mesh.Value];
+    //            mesh.
+    //        }
+    //    }
+    //}
 }

--- a/glTFRevitExport/glTF.cs
+++ b/glTFRevitExport/glTF.cs
@@ -29,6 +29,12 @@ namespace glTFRevitExport
         FLOAT = 5126
     }
 
+    public struct glTFContainer
+    {
+        public glTF glTF;
+        public List<glTFBinaryData> binaries;
+    }
+
     /// <summary>
     /// The json serializable glTF file format.
     /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0

--- a/glTFRevitExport/glTFRevitExport.csproj
+++ b/glTFRevitExport/glTFRevitExport.csproj
@@ -9,27 +9,118 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>glTFRevitExport</RootNamespace>
     <AssemblyName>glTFRevitExport</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition="$(Configuration.Contains('2017'))">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RevitVersion>2017</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('2018'))">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <RevitVersion>2018</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('2019'))">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RevitVersion>2019</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('2020'))">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RevitVersion>2020</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('2021'))">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <RevitVersion>2021</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2017|x64'">
+    <OutputPath>bin\Debug2017\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;REVIT2017</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2018|x64'">
+    <OutputPath>bin\Debug2018\</OutputPath>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;REVIT2018</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2019|x64'">
+    <OutputPath>bin\Debug2019\</OutputPath>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;REVIT2019</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2020|x64'">
+    <OutputPath>bin\Debug2020\</OutputPath>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;REVIT2020</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug2021|x64'">
+    <OutputPath>bin\Debug2021\</OutputPath>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;REVIT2021</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2017|x64'">
+    <OutputPath>bin\Release2017\</OutputPath>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>REVIT2017</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2018|x64'">
+    <OutputPath>bin\Release2018\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>REVIT2018</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2019|x64'">
+    <OutputPath>bin\Release2019\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>REVIT2019</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2020|x64'">
+    <OutputPath>bin\Release2020\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>REVIT2020</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release2021|x64'">
+    <OutputPath>bin\Release2021\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>REVIT2021</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -37,17 +128,6 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="RevitAPI">
-      <HintPath>C:\Users\rmccullough\Documents\_Dev\Revit\Assets\RevitAPI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RevitAPIUI">
-      <HintPath>C:\Users\rmccullough\Documents\_Dev\Revit\Assets\RevitAPIUI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Web.Extensions" />
@@ -98,7 +178,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -111,6 +190,12 @@
     </Content>
     <EmbeddedResource Include="Embedded Media\small.png" />
     <EmbeddedResource Include="Embedded Media\large.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="Revit_All_Main_Versions_API_x64" Version="$(RevitVersion).0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/glTFRevitExport/glTFRevitExport.csproj
+++ b/glTFRevitExport/glTFRevitExport.csproj
@@ -73,6 +73,7 @@
     <Compile Include="glTF.cs" />
     <Compile Include="GlTFExportContext.cs" />
     <Compile Include="Containers.cs" />
+    <Compile Include="GLTFManager.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="WPF\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/glTFRevitExport/packages.config
+++ b/glTFRevitExport/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Updates that improve file size, cover more cases, and provide a more detailed output. 

- Each object is now exported in local coordinates with a transform attached.
- Nodes with identical geometries now reference a single mesh instead of duplicating it (mesh instancing).
- Build targets for each Revit version.
- Material transparencies now exported.
- Config object now used for export options.